### PR TITLE
MySQL 5.7 breaking changes fails to install

### DIFF
--- a/pluggable_node_access.install
+++ b/pluggable_node_access.install
@@ -15,6 +15,7 @@ function pluggable_node_access_schema() {
     'fields' => array(
       'id' => array(
         'type' => 'serial',
+        'not null' => TRUE,
         'unsigned' => TRUE,
         'description' => 'The Unique ID of the Pluggable node access.',
       ),


### PR DESCRIPTION
All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead
